### PR TITLE
修复因为无歌手导致的数组越界

### DIFF
--- a/src/main/java/com/gly091020/hud/MusicListLayer.java
+++ b/src/main/java/com/gly091020/hud/MusicListLayer.java
@@ -156,7 +156,7 @@ public class MusicListLayer{
                 artists.append(", ");
             }
         }
-        return (NetMusicListKeyMapping.TOGGLE_MUSIC_TRANSFORM.isDown() ? getTransName(info) : info.songName) + artists.substring(0, artists.length() - 2);
+        return (NetMusicListKeyMapping.TOGGLE_MUSIC_TRANSFORM.isDown() ? getTransName(info) : info.songName) + ((artists.isEmpty())? "":artists.substring(0, artists.length() - 2));
     }
 
     private static String getTransName(ItemMusicCD.SongInfo info){


### PR DESCRIPTION
通过一个三元运算符来判断是否有歌手，从而防止崩溃报错